### PR TITLE
feat: add collect transform

### DIFF
--- a/autofeat/transform/__init__.py
+++ b/autofeat/transform/__init__.py
@@ -3,6 +3,7 @@ __all__ = [
     "AllOf",
     "AnyOf",
     "Cast",
+    "Collect",
     "Combine",
     "Drop",
     "Encode",
@@ -22,6 +23,7 @@ from autofeat.transform.all_of import AllOf
 from autofeat.transform.any_of import AnyOf
 from autofeat.transform.base import Transform
 from autofeat.transform.cast import Cast
+from autofeat.transform.collect import Collect
 from autofeat.transform.combine import Combine
 from autofeat.transform.drop import Drop
 from autofeat.transform.encode import Encode

--- a/autofeat/transform/base.py
+++ b/autofeat/transform/base.py
@@ -57,7 +57,7 @@ class Transform(abc.ABC):
             else:
                 transforms.append(
                     AllOf(
-                        transforms=[
+                        [
                             *(self.transforms if isinstance(self, AllOf) else [self]),
                             *(next.transforms if isinstance(next, AllOf) else [next]),
                         ],
@@ -67,4 +67,4 @@ class Transform(abc.ABC):
         if len(transforms) == 1:
             return transforms[0]
         else:
-            return AnyOf(transforms=transforms)
+            return AnyOf(transforms)

--- a/autofeat/transform/collect.py
+++ b/autofeat/transform/collect.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING
+
+import polars
+
+from autofeat.table import Table
+from autofeat.transform import Transform
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+@dataclasses.dataclass(kw_only=True)
+class Collect(Transform):
+    """Collect all tables in memory.
+
+    :param streaming: Whether or not to use the Polars streaming engine.
+    """
+
+    streaming: bool = True
+
+    def apply(
+        self,
+        tables: Iterable[Table],
+    ) -> Iterable[Table]:
+        tables = list(tables)
+
+        data = polars.collect_all(
+            (table.data for table in tables),
+            streaming=self.streaming,
+        )
+
+        for table, df in zip(tables, data):
+            yield Table(
+                columns=table.columns,
+                data=df.lazy(),
+                name=table.name,
+            )


### PR DESCRIPTION
- when you evaluate the same computation graph multiple times (e.g., when you are iteratively training a model) we are currently recomputing the entire graph on every cycle - it would be more efficient to cache the results from the previous iteration