### PR TITLE
feat: support for specifying kaggle competitions using shortened url

### DIFF
--- a/autofeat/source/from_kaggle.py
+++ b/autofeat/source/from_kaggle.py
@@ -45,8 +45,8 @@ def from_kaggle(
     :param cache: Path where data is locally cached.
     :return: Kaggle dataset.
     """
-    if match := re.match(r"^.*kaggle\.com/competitions/([^\/\?\#]+).*$", name_or_url):
-        name = match.group(1)
+    if match := re.match(r"^.*kaggle\.com/c(ompetitions)?/([^\/\?\#]+).*$", name_or_url):
+        name = match.group(2)
     elif match := re.match(r"^.*kaggle\.com/datasets/([^\/]+/[^\/\?\#]+).*$", name_or_url):
         name = match.group(1)
     else:


### PR DESCRIPTION
- allows passing competitions like https://www.kaggle.com/c/house-prices-advanced-regression-techniques/data