### PR TITLE
wip: switching computers

### DIFF
--- a/autofeat/model.py
+++ b/autofeat/model.py
@@ -461,7 +461,7 @@ class Model:  # type: ignore[no-any-unimported]
                     for column in table.columns
                     if column.is_related(target_column)
                 ],
-            ),
+            ).then(Join()),
         )
 
         # repeatedly transform the dataset and train a prediction model on the top n features

--- a/autofeat/transform/cast.py
+++ b/autofeat/transform/cast.py
@@ -9,7 +9,7 @@ from autofeat.table import Column, Table
 from autofeat.transform.base import Transform
 
 # Number of rows to test casts on.
-SAMPLE_SIZE = 10
+SAMPLE_SIZE = 25
 
 
 @attrs.define(frozen=True, kw_only=True, slots=True)

--- a/autofeat/transform/encode.py
+++ b/autofeat/transform/encode.py
@@ -73,14 +73,14 @@ class Encode(Transform):
         for column in self._categorical_columns(table):
             categories = next(category_iterator).to_series()
 
-            if Attribute.textual in column.attributes:
-                column = Column(
-                    name=column.name,
-                    attributes=column.attributes,
-                    derived_from=[(column, table)],
-                )
+            # if Attribute.textual in column.attributes:
+            #     column = Column(
+            #         name=column.name,
+            #         attributes=column.attributes,
+            #         derived_from=[(column, table)],
+            #     )
 
-                yield column, column.expr.cast(polars.Enum(categories=categories))
+            #     yield column, column.expr.cast(polars.Enum(categories=categories))
 
             for category in categories:
                 encoded_column = Column(

--- a/autofeat/transform/join.py
+++ b/autofeat/transform/join.py
@@ -1,7 +1,9 @@
+import functools
 import itertools
 from collections.abc import Iterable
 
 import attrs
+import networkx
 
 from autofeat.attribute import Attribute
 from autofeat.table import Table
@@ -16,52 +18,75 @@ class Join(Transform):
         self,
         tables: Iterable[Table],
     ) -> Iterable[Table]:
-        tables = list(tables)
+        for related_tables in self._related_tables(list(tables)):
+            if len(related_tables) == 1:
+                yield related_tables[0]
+            else:
+                yield functools.reduce(
+                    lambda x, y: Table(
+                        name=f"{x.name}, {y.name}",
+                        data=x.data.join(
+                            y.data,
+                            how="outer",
+                            on=self._key_columns(x, y),
+                        ),
+                        columns=[
+                            *x.columns,
+                            *[
+                                y_column
+                                for y_column in y.columns
+                                if all(y_column.name != x_column.name for x_column in x.columns)
+                            ],
+                        ],
+                    ),
+                    related_tables,
+                )
 
-        primary_keys = {
-            table.name: {
-                column.name
-                for column in table.columns
-                if Attribute.primary_key in column.attributes
-            }
-            for table in tables
+    def _key_columns(
+        self,
+        x: Table,
+        y: Table,
+    ) -> list[str]:
+        x_columns = {
+            column.name
+            for column in x.columns
         }
 
-        column_names = {
-            table.name: {
-                column.name
-                for column in table.columns
-            }
-            for table in tables
+        x_primary_key = {
+            column.name
+            for column in x.columns
+            if Attribute.primary_key in column.attributes
         }
+
+        y_columns = {
+            column.name
+            for column in y.columns
+        }
+
+        y_primary_key = {
+            column.name
+            for column in y.columns
+            if Attribute.primary_key in column.attributes
+        }
+
+        if x_primary_key and x_primary_key <= y_columns:
+            return list(x_primary_key)
+        elif y_primary_key and y_primary_key <= x_columns:
+            return list(y_primary_key)
+        else:
+            return []
+
+    def _related_tables(
+        self,
+        tables: list[Table],
+    ) -> list[list[Table]]:
+        graph: networkx.Graph[Table] = networkx.Graph()
+
+        for table in tables:
+            graph.add_node(table)
 
         for x, y in itertools.combinations(tables, 2):
-            # TODO: should check if the primary keys share common ancestors
-            if x.name not in y.name and y.name not in x.name:
-                x_primary_key = primary_keys[x.name]
-                x_column_names = column_names[x.name]
-                y_primary_key = primary_keys[y.name]
-                y_column_names = column_names[y.name]
+            if self._key_columns(x, y):
+                graph.add_edge(x, y)
 
-                if y_primary_key and y_primary_key <= x_column_names:
-                    columns = [
-                        *list(x.columns),
-                        *[column for column in y.columns if column.name not in x_column_names],
-                    ]
-
-                    yield Table(
-                        data=x.data.join(y.data, on=list(y_primary_key), how="left"),
-                        name=f"join({x.name}, {y.name})",
-                        columns=columns,
-                    )
-                elif x_primary_key and x_primary_key <= y_column_names:
-                    columns = [
-                        *list(y.columns),
-                        *[column for column in x.columns if column.name not in y_column_names],
-                    ]
-
-                    yield Table(
-                        data=y.data.join(x.data, on=list(x_primary_key), how="left"),
-                        name=f"join({y.name}, {x.name})",
-                        columns=columns,
-                    )
+        return list(networkx.connected_components(graph))

--- a/autofeat/ui/load_dataset.py
+++ b/autofeat/ui/load_dataset.py
@@ -4,7 +4,7 @@ from typing import ParamSpec
 import streamlit
 
 from autofeat import Dataset, source
-from autofeat.transform import Cast, Encode, Shrink
+from autofeat.transform import Cast, Encode
 
 P = ParamSpec("P")
 
@@ -75,4 +75,4 @@ def _source_dataset(
     **kwargs: P.kwargs,
 ) -> Dataset:
     dataset = _loader(*args, **kwargs)
-    return dataset.apply(Cast().then(Encode()).then(Shrink()))
+    return dataset.apply(Cast().then(Encode()))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
 [tool.mypy]
+allow_redefinition = true
 check_untyped_defs = true
 disallow_any_unimported = true
 disallow_untyped_defs = true


### PR DESCRIPTION
- the current problem is that the order of the join matters
- suppose you have three tables with primary keys A, A and B, and B and C
- these tables could be joined together by joining 1 or 3 with 2 and then joining the result with the remaining table
- but if you join 1 with 3 first it breaks because the join columns don't overlap
- we need to think of some way to ensure that we join the tables in an appropriate order
- perhaps via a topological sort after calculating connected components?